### PR TITLE
Avoid use of StringIO

### DIFF
--- a/lib/exfile_s3/backend.ex
+++ b/lib/exfile_s3/backend.ex
@@ -44,7 +44,7 @@ defmodule ExfileS3.Backend do
   def open(backend, file_id) do
     case S3.get_object(S3.find_config_value(:bucket), path(backend, file_id)) do
       {:ok, %{body: body}} ->
-        {:ok, io} = StringIO.open(body)
+        {:ok, io} = File.open(body, [:ram, :binary, :read])
         {:ok, %LocalFile{io: io}}
       {:error, reason} ->
         {:error, reason}


### PR DESCRIPTION
StringIO doesn't support rewinding, which Exfile uses to make sure it's getting the whole file instead of a partial file.

This caught me up when I was working on Exfile too, so much so that I decided it was a good idea to write a blog post about it: https://kkob.us/2016/01/23/elixirs-stringio-may-not-be-what-you-think-it-is/
